### PR TITLE
Tweak default behaviours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+
+- Many new convenience functions, such as `Anthology.get_person()`, `Anthology.find_people()`, `Volume.get_events()`, `Person.papers()`, `Person.volumes()`.
+
+### Changed
+
+- Showing progress bars (i.e. `verbose=True`) is now the default.
+- Shorter `repr()` output for many classes, sacrificing detail for better usability in interactive settings.
+- `Person` objects now require a pointer to the Anthology instance.
+
 ## [0.4.1] — 2023-10-14
 
 ### Added

--- a/acl_anthology/anthology.py
+++ b/acl_anthology/anthology.py
@@ -75,6 +75,9 @@ class Anthology:
         self.venues = VenueIndex(self)
         """The [VenueIndex][acl_anthology.venues.VenueIndex] for accessing venues."""
 
+    def __repr__(self) -> str:
+        return f"Anthology(datadir={repr(self.datadir)}, verbose={self.verbose})"
+
     def _check_schema_compatibility(self) -> None:
         """
         Checks if the XML schema in the data directory is identical to

--- a/acl_anthology/anthology.py
+++ b/acl_anthology/anthology.py
@@ -49,10 +49,10 @@ class Anthology:
 
     Attributes:
         datadir (PathLike[str]): The path to the data folder.
-        verbose (bool): If True, will show progress bars during longer operations.
+        verbose (bool): If False, will not show progress bars during longer operations.
     """
 
-    def __init__(self, datadir: PathLike[str], verbose: bool = False) -> None:
+    def __init__(self, datadir: PathLike[str], verbose: bool = True) -> None:
         if not Path(datadir).is_dir():
             raise FileNotFoundError(f"Not a directory: {datadir}")
 
@@ -91,14 +91,14 @@ class Anthology:
         cls,
         repo_url: str = "https://github.com/acl-org/acl-anthology.git",
         path: Optional[PathLike[str]] = None,
-        verbose: bool = False,
+        verbose: bool = True,
     ) -> Self:
         """Instantiates the Anthology from a Git repo.
 
         Arguments:
             repo_url: The URL of a Git repo with Anthology data.  If not given, defaults to the official ACL Anthology repo.
             path: The local path for the repo data.  If not given, automatically determines a path within the user's data directory.
-            verbose: If True, will show progress bars during longer operations.
+            verbose: If False, will not show progress bars during longer operations.
         """
         if path is None:
             path = (

--- a/acl_anthology/anthology.py
+++ b/acl_anthology/anthology.py
@@ -236,6 +236,17 @@ class Anthology:
             return None
         return volume.get(paper_id)
 
+    def get_person(self, person_id: str) -> Optional[Person]:
+        """Access a person by their ID.
+
+        Parameters:
+            person_id: An ID that refers to a person.
+
+        Returns:
+            The person associated with the given ID.
+        """
+        return self.people.get(person_id)
+
     def find_people(self, name_def: ConvertableIntoName) -> list[Person]:
         """Find people by name.
 

--- a/acl_anthology/anthology.py
+++ b/acl_anthology/anthology.py
@@ -35,7 +35,7 @@ from .exceptions import SchemaMismatchWarning
 from .utils import git
 from .utils.ids import AnthologyID, parse_id
 from .collections import CollectionIndex, Collection, Volume, Paper, EventIndex
-from .people import PersonIndex, Person, NameSpecification
+from .people import PersonIndex, Person, Name, NameSpecification, ConvertableIntoName
 from .sigs import SIGIndex
 from .venues import VenueIndex
 
@@ -235,6 +235,25 @@ class Anthology:
         if volume is None or paper_id is None:
             return None
         return volume.get(paper_id)
+
+    def find_people(self, name_def: ConvertableIntoName) -> list[Person]:
+        """Find people by name.
+
+        Parameters:
+            name_def: Anything that can be resolved to a name; see below for examples.
+
+        Returns:
+            A list of [`Person`][acl_anthology.people.person.Person] objects with the given name.
+
+        Examples:
+            >>> anthology.find_persons("Doe, Jane")
+            >>> anthology.find_persons(("Jane", "Doe"))       # same as above
+            >>> anthology.find_persons({"first": "Jane",
+                                         "last": "Doe"})      # same as above
+            >>> anthology.find_persons(Name("Jane", "Doe"))   # same as above
+        """
+        name = Name.from_(name_def)
+        return self.people.get_by_name(name)
 
     @overload
     def resolve(self, name_spec: NameSpecification) -> Person:

--- a/acl_anthology/collections/event.py
+++ b/acl_anthology/collections/event.py
@@ -53,7 +53,9 @@ class Event:
     parent: Collection = field(repr=False, eq=False)
     is_explicit: bool = field(default=False)
 
-    colocated_ids: list[AnthologyIDTuple] = field(factory=list, repr=False)
+    colocated_ids: list[AnthologyIDTuple] = field(
+        factory=list, repr=lambda x: f"<list of {len(x)} AnthologyIDTuple items>"
+    )
     links: dict[str, AttachmentReference] = field(factory=dict, repr=False)
     talks: list[Talk] = field(factory=list, repr=False)
 

--- a/acl_anthology/collections/event.py
+++ b/acl_anthology/collections/event.py
@@ -54,7 +54,7 @@ class Event:
     is_explicit: bool = field(default=False)
 
     colocated_ids: list[AnthologyIDTuple] = field(
-        factory=list, repr=lambda x: f"<list of {len(x)} AnthologyIDTuple items>"
+        factory=list, repr=lambda x: f"<list of {len(x)} AnthologyIDTuple objects>"
     )
     links: dict[str, AttachmentReference] = field(factory=dict, repr=False)
     talks: list[Talk] = field(factory=list, repr=False)

--- a/acl_anthology/collections/event.py
+++ b/acl_anthology/collections/event.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from attrs import define, field
 from lxml import etree
 from lxml.builder import E
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, Iterator, Optional, TYPE_CHECKING
 
 from ..files import AttachmentReference
 from ..people import NameSpecification
@@ -26,7 +26,7 @@ from ..utils.ids import AnthologyIDTuple, parse_id, build_id_from_tuple
 
 if TYPE_CHECKING:
     from ..anthology import Anthology
-    from . import Collection
+    from . import Collection, Volume
 
 
 @define
@@ -72,6 +72,17 @@ class Event:
     def root(self) -> Anthology:
         """The Anthology instance to which this object belongs."""
         return self.parent.parent.parent
+
+    def volumes(self) -> Iterator[Volume]:
+        """Returns an iterator over all volumes co-located with this event."""
+        for anthology_id in self.colocated_ids:
+            volume = self.root.get_volume(anthology_id)
+            if volume is None:
+                raise ValueError(
+                    f"Event {self.id} lists co-located volume "
+                    f"{build_id_from_tuple(anthology_id)}, which doesn't exist"
+                )
+            yield volume
 
     @classmethod
     def from_xml(cls, parent: Collection, event: etree._Element) -> Event:

--- a/acl_anthology/collections/eventindex.py
+++ b/acl_anthology/collections/eventindex.py
@@ -37,13 +37,13 @@ class EventIndex(SlottedDict[Event]):
 
     Attributes:
         parent: The parent Anthology instance to which this index belongs.
-        verbose: If True, will show progress bar when building the index from scratch.
+        verbose: If False, will not show progress bar when building the index from scratch.
         reverse: A mapping of volume IDs to a set of associated event IDs.
         is_data_loaded: A flag indicating whether the index has been constructed.
     """
 
     parent: Anthology = field(repr=False, eq=False)
-    verbose: bool = field(default=False)
+    verbose: bool = field(default=True)
     reverse: dict[AnthologyIDTuple, set[str]] = field(
         init=False, repr=False, factory=lambda: defaultdict(set)
     )

--- a/acl_anthology/collections/paper.py
+++ b/acl_anthology/collections/paper.py
@@ -73,29 +73,29 @@ class Paper:
 
     id: str
     parent: Volume = field(repr=False, eq=False)
-    bibkey: str
+    bibkey: str = field()
     title: MarkupText = field()
 
-    attachments: dict[str, AttachmentReference] = Factory(dict)
+    attachments: dict[str, AttachmentReference] = field(factory=dict, repr=False)
     authors: list[NameSpecification] = Factory(list)
-    awards: list[str] = Factory(list)
+    awards: list[str] = field(factory=list, repr=False)
     # TODO: why can a Paper ever have "editors"? it's allowed by the schema
-    editors: list[NameSpecification] = Factory(list)
-    errata: list[PaperErratum] = Factory(list)
-    revisions: list[PaperRevision] = Factory(list)
-    videos: list[VideoReference] = Factory(list)
+    editors: list[NameSpecification] = field(factory=list, repr=False)
+    errata: list[PaperErratum] = field(factory=list, repr=False)
+    revisions: list[PaperRevision] = field(factory=list, repr=False)
+    videos: list[VideoReference] = field(factory=list, repr=False)
 
     abstract: Optional[MarkupText] = field(default=None)
-    deletion: Optional[PaperDeletionNotice] = field(default=None)
-    doi: Optional[str] = field(default=None)
-    ingest_date: Optional[str] = field(default=None)
-    language: Optional[str] = field(default=None)
-    note: Optional[str] = field(default=None)
-    pages: Optional[str] = field(default=None)
+    deletion: Optional[PaperDeletionNotice] = field(default=None, repr=False)
+    doi: Optional[str] = field(default=None, repr=False)
+    ingest_date: Optional[str] = field(default=None, repr=False)
+    language: Optional[str] = field(default=None, repr=False)
+    note: Optional[str] = field(default=None, repr=False)
+    pages: Optional[str] = field(default=None, repr=False)
     paperswithcode: Optional[PapersWithCodeReference] = field(
-        default=None, on_setattr=attrs.setters.frozen
+        default=None, on_setattr=attrs.setters.frozen, repr=False
     )
-    pdf: Optional[PDFReference] = field(default=None)
+    pdf: Optional[PDFReference] = field(default=None, repr=False)
 
     # TODO: properties we obtain from the parent volume?
 

--- a/acl_anthology/collections/paper.py
+++ b/acl_anthology/collections/paper.py
@@ -97,8 +97,6 @@ class Paper:
     )
     pdf: Optional[PDFReference] = field(default=None, repr=False)
 
-    # TODO: properties we obtain from the parent volume?
-
     @property
     def collection_id(self) -> str:
         """The collection ID this paper belongs to."""
@@ -133,6 +131,40 @@ class Paper:
     def root(self) -> Anthology:
         """The Anthology instance to which this object belongs."""
         return self.parent.parent.parent.parent
+
+    @property
+    def address(self) -> Optional[str]:
+        """The publisher's address for this paper. Inherited from the parent Volume."""
+        return self.parent.address
+
+    @property
+    def month(self) -> Optional[str]:
+        """The month of publication. Inherited from the parent Volume."""
+        return self.parent.month
+
+    @property
+    def publisher(self) -> Optional[str]:
+        """The paper's publisher. Inherited from the parent Volume."""
+        return self.parent.publisher
+
+    @property
+    def venue_ids(self) -> list[str]:
+        """List of venue IDs associated with this paper. Inherited from the parent Volume."""
+        return self.parent.venue_ids
+
+    @property
+    def year(self) -> str:
+        """The year of publication. Inherited from the parent Volume."""
+        return self.parent.year
+
+    def get_editors(self) -> list[NameSpecification]:
+        """
+        Returns:
+            `self.editors`, if not empty; the parent volume's editors otherwise.
+        """
+        if self.editors:
+            return self.editors
+        return self.parent.editors
 
     def get_ingest_date(self) -> datetime.date:
         """

--- a/acl_anthology/collections/paper.py
+++ b/acl_anthology/collections/paper.py
@@ -35,7 +35,7 @@ from ..utils.logging import get_logger
 
 if TYPE_CHECKING:
     from ..anthology import Anthology
-    from . import Volume
+    from . import Event, Volume
 
 log = get_logger()
 
@@ -165,6 +165,13 @@ class Paper:
         if self.editors:
             return self.editors
         return self.parent.editors
+
+    def get_events(self) -> list[Event]:
+        """
+        Returns:
+            A list of events associated with this paper.
+        """
+        return self.root.events.by_volume(self.parent.full_id_tuple)
 
     def get_ingest_date(self) -> datetime.date:
         """

--- a/acl_anthology/collections/volume.py
+++ b/acl_anthology/collections/volume.py
@@ -33,7 +33,7 @@ from .paper import Paper
 
 if TYPE_CHECKING:
     from ..anthology import Anthology
-    from . import Collection
+    from . import Collection, Event
 
 
 class VolumeType(Enum):
@@ -135,6 +135,13 @@ class Volume(SlottedDict[Paper]):
     def root(self) -> Anthology:
         """The Anthology instance to which this object belongs."""
         return self.parent.parent.parent
+
+    def get_events(self) -> list[Event]:
+        """
+        Returns:
+            A list of events associated with this volume.
+        """
+        return self.root.events.by_volume(self.full_id_tuple)
 
     def get_ingest_date(self) -> datetime.date:
         """

--- a/acl_anthology/collections/volume.py
+++ b/acl_anthology/collections/volume.py
@@ -79,27 +79,26 @@ class Volume(SlottedDict[Paper]):
 
     id: str
     parent: Collection = field(repr=False, eq=False)
-    type: VolumeType
+    type: VolumeType = field(repr=False)
     title: MarkupText = field(alias="booktitle")
-    year: str
+    year: str = field()
 
     editors: list[NameSpecification] = Factory(list)
     venue_ids: list[str] = field(factory=list)
 
-    address: Optional[str] = field(default=None)
-    doi: Optional[str] = field(default=None)
-    ingest_date: Optional[str] = field(default=None)
-    isbn: Optional[str] = field(default=None)
-    journal_issue: Optional[str] = field(default=None)
-    journal_volume: Optional[str] = field(default=None)
-    journal_title: Optional[str] = field(default=None)
-    month: Optional[str] = field(default=None)
-    pdf: Optional[PDFReference] = field(default=None)
-    publisher: Optional[str] = field(default=None)
-    shorttitle: Optional[MarkupText] = field(default=None, alias="shortbooktitle")
-
-    # def __repr__(self) -> str:
-    #    return f"Volume({self._parent_id!r}, {self._id!r})"
+    address: Optional[str] = field(default=None, repr=False)
+    doi: Optional[str] = field(default=None, repr=False)
+    ingest_date: Optional[str] = field(default=None, repr=False)
+    isbn: Optional[str] = field(default=None, repr=False)
+    journal_issue: Optional[str] = field(default=None, repr=False)
+    journal_volume: Optional[str] = field(default=None, repr=False)
+    journal_title: Optional[str] = field(default=None, repr=False)
+    month: Optional[str] = field(default=None, repr=False)
+    pdf: Optional[PDFReference] = field(default=None, repr=False)
+    publisher: Optional[str] = field(default=None, repr=False)
+    shorttitle: Optional[MarkupText] = field(
+        default=None, alias="shortbooktitle", repr=False
+    )
 
     @property
     def frontmatter(self) -> Paper | None:

--- a/acl_anthology/containers.py
+++ b/acl_anthology/containers.py
@@ -27,6 +27,13 @@ T = TypeVar("T")
 U = TypeVar("U")
 
 
+def dict_type(x: dict[str, T]) -> str:
+    if not x:
+        return ""
+    value = next(iter(x.values()))
+    return f"{value.__class__.__name__} "
+
+
 @define
 class SlottedDict(Generic[T]):
     """A generic slotted class for dictionary-like behavior.
@@ -40,7 +47,13 @@ class SlottedDict(Generic[T]):
         is_data_loaded: Flag that defaults to True. Subclasses can set this to False to indicate that [`self.load()`][acl_anthology.containers.SlottedDict.load] must be called before any data can be accessed; in that case, they also have to implement the `load` function.
     """
 
-    data: dict[str, T] = field(init=False, repr=False, factory=dict)
+    # TODO: We would probably like to take is_data_loaded into account, but
+    # that's not really possible
+    data: dict[str, T] = field(
+        init=False,
+        repr=lambda x: f"<dict of {len(x)} {dict_type(x)}item{'' if len(x) == 1 else 's'}>",
+        factory=dict,
+    )
     is_data_loaded: bool = field(init=False, repr=False, default=True)
 
     def __contains__(self, key: str) -> bool:

--- a/acl_anthology/people/__init__.py
+++ b/acl_anthology/people/__init__.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .name import Name, NameSpecification
+from .name import Name, NameSpecification, ConvertableIntoName
 from .person import Person
 from .index import PersonIndex
 
-__all__ = ["Name", "NameSpecification", "Person", "PersonIndex"]
+__all__ = ["ConvertableIntoName", "Name", "NameSpecification", "Person", "PersonIndex"]

--- a/acl_anthology/people/index.py
+++ b/acl_anthology/people/index.py
@@ -239,7 +239,7 @@ class PersonIndex(SlottedDict[Person]):
             except KeyError:
                 if create:
                     # If it doesn't, only then do we create a new perosn
-                    person = Person(id=pid, names=[name])
+                    person = Person(id=pid, parent=self.parent, names=[name])
                     self.add_person(person)
                 else:
                     raise NameIDUndefinedError(
@@ -292,7 +292,12 @@ class PersonIndex(SlottedDict[Person]):
                 Name.from_dict(var) for var in entry.get("variants", [])
             ]
             # Now we can create a new person from this entry...
-            person = Person(id=pid, names=names, comment=entry.get("comment", None))
+            person = Person(
+                id=pid,
+                parent=self.parent,
+                names=names,
+                comment=entry.get("comment", None),
+            )
             # ...and add it to the index
             self.add_person(person)
             for similar_id in entry.get("similar", []):

--- a/acl_anthology/people/index.py
+++ b/acl_anthology/people/index.py
@@ -51,14 +51,14 @@ class PersonIndex(SlottedDict[Person]):
 
     Attributes:
         parent: The parent Anthology instance to which this index belongs.
-        verbose: If True, will show progress bar when building the index from scratch.
+        verbose: If False, will not show progress bar when building the index from scratch.
         name_to_ids: A mapping of [Name][acl_anthology.people.name.Name] instances to person IDs.
         similar: A [disjoint-set structure][scipy.cluster.hierarchy.DisjointSet] of persons with similar names.
         is_data_loaded: A flag indicating whether the index has been constructed.
     """
 
     parent: Anthology = field(repr=False, eq=False)
-    verbose: bool = field(default=False)
+    verbose: bool = field(default=True)
     name_to_ids: dict[Name, list[str]] = field(
         init=False, repr=False, factory=lambda: defaultdict(list)
     )

--- a/acl_anthology/people/name.py
+++ b/acl_anthology/people/name.py
@@ -82,17 +82,17 @@ class Name:
         return slug
 
     @classmethod
-    def from_dict(cls, person: dict[str, str]) -> Name:
+    def from_dict(cls, name: dict[str, str]) -> Name:
         """
         Parameters:
-            person: A dictionary with "first" and "last" keys.
+            name: A dictionary with "first" and "last" keys.
 
         Returns:
             A corresponding Name object.
         """
         return cls(
-            person.get("first"),
-            person["last"],
+            name.get("first"),
+            name["last"],
         )
 
     @classmethod
@@ -119,6 +119,32 @@ class Name:
             elif element.tag == "last":
                 last = element.text
         return cls(first, cast(str, last), script)
+
+    @classmethod
+    def from_string(cls, name: str) -> Name:
+        """Instantiate a Name from a single string.
+
+        Parameters:
+            name: A name string given as either "{first} {last}" or "{last}, {first}".
+
+        Returns:
+            A corresponding Name object.
+
+        Raises:
+            ValueError: If `name` cannot be unambiguously parsed into first/last components; in this case, you should instantiate Name directly instead.
+        """
+        name = name.strip()
+        if ", " in name:
+            components = name.split(", ")[::-1]
+        else:
+            components = name.split(" ")
+        if len(components) == 1:
+            components.insert(0, None)
+        elif len(components) > 2:
+            raise ValueError(
+                f"Name string cannot be unambiguously parsed into first/last components: {name}"
+            )
+        return cls(components[0], components[1])
 
     def to_xml(self, tag: str = "variant") -> etree._Element:
         """

--- a/acl_anthology/people/name.py
+++ b/acl_anthology/people/name.py
@@ -139,12 +139,37 @@ class Name:
         else:
             components = name.split(" ")
         if len(components) == 1:
-            components.insert(0, None)
+            return cls(None, components[0])
         elif len(components) > 2:
             raise ValueError(
                 f"Name string cannot be unambiguously parsed into first/last components: {name}"
             )
         return cls(components[0], components[1])
+
+    @classmethod
+    def from_(cls, name: ConvertableIntoName) -> Name:
+        """Instantiate a Name dynamically from any type that can be converted into a Name.
+
+        Parameters:
+            name: A name as a string, dict, tuple, or Name instance.
+
+        Returns:
+            A corresponding Name object.
+
+        Raises:
+            ValueError:
+            TypeError:
+        """
+        if isinstance(name, cls):
+            return name
+        elif isinstance(name, dict):
+            return cls.from_dict(name)
+        elif isinstance(name, tuple):
+            return cls(*name)
+        elif isinstance(name, str):
+            return cls.from_string(name)
+        else:
+            raise TypeError(f"Cannot instantiate Name from {type(name)}")
 
     def to_xml(self, tag: str = "variant") -> etree._Element:
         """
@@ -164,6 +189,10 @@ class Name:
         if self.script is not None:
             elem.set("script", self.script)
         return elem
+
+
+ConvertableIntoName = Name | str | tuple[Optional[str], str] | dict[str, str]
+"""A type that can be converted into a Name instance."""
 
 
 @define

--- a/acl_anthology/people/person.py
+++ b/acl_anthology/people/person.py
@@ -15,9 +15,12 @@
 from __future__ import annotations
 
 from attrs import define, field, Factory
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 from ..utils.ids import AnthologyIDTuple
 from . import Name
+
+if TYPE_CHECKING:
+    from ..anthology import Anthology
 
 
 @define
@@ -26,15 +29,17 @@ class Person:
 
     Attributes:
         id: A unique ID for this person.
+        parent: The parent Anthology instance to which this person belongs.
         names: A list of names under which this person has published.
         item_ids: A set of volume and/or paper IDs this person has authored or edited.
         comment: A comment for disambiguation purposes; can be stored in `name_variants.yaml`.
     """
 
     id: str
+    parent: Anthology = field(repr=False, eq=False)
     names: list[Name] = Factory(list)
     item_ids: set[AnthologyIDTuple] = field(
-        factory=set, repr=lambda x: f"<set of {len(x)} AnthologyIDTuple items>"
+        factory=set, repr=lambda x: f"<set of {len(x)} AnthologyIDTuple objects>"
     )
     comment: Optional[str] = field(default=None)
 

--- a/acl_anthology/people/person.py
+++ b/acl_anthology/people/person.py
@@ -33,7 +33,9 @@ class Person:
 
     id: str
     names: list[Name] = Factory(list)
-    item_ids: set[AnthologyIDTuple] = Factory(set)
+    item_ids: set[AnthologyIDTuple] = field(
+        factory=set, repr=lambda x: f"<set of {len(x)} AnthologyIDTuple items>"
+    )
     comment: Optional[str] = field(default=None)
 
     @property

--- a/acl_anthology/text/markuptext.py
+++ b/acl_anthology/text/markuptext.py
@@ -79,6 +79,7 @@ class MarkupText:
     def __str__(self) -> str:
         return self.as_text()
 
+    # TODO: This is expensive to produce; should as_html be cached?
     def __repr__(self) -> str:
         return f"MarkupText({self.as_html()!r})"
 

--- a/acl_anthology/text/markuptext.py
+++ b/acl_anthology/text/markuptext.py
@@ -20,7 +20,7 @@ from attrs import define, field
 from collections import defaultdict
 from copy import deepcopy
 from lxml import etree
-from typing import Iterator
+from typing import Iterator, Optional
 
 from ..utils import (
     latex_encode,
@@ -76,12 +76,16 @@ class MarkupText:
     # alternative that doesn't require deepcopy-ing XML elements at all.
     _content: etree._Element | str = field()
 
+    # For caching
+    _html: Optional[str] = field(init=False, default=None)
+    _latex: Optional[str] = field(init=False, default=None)
+    _text: Optional[str] = field(init=False, default=None)
+
     def __str__(self) -> str:
         return self.as_text()
 
-    # TODO: This is expensive to produce; should as_html be cached?
     def __repr__(self) -> str:
-        return f"MarkupText({self.as_html()!r})"
+        return f"<MarkupText {self.as_html()!r}>"
 
     def __rich_repr__(self) -> Iterator[str]:
         yield self.as_html()
@@ -93,13 +97,15 @@ class MarkupText:
         """
         if isinstance(self._content, str):
             return self._content
+        if self._text is not None:
+            return self._text
         element = deepcopy(self._content)
         for sub in element.iterfind(".//tex-math"):
             sub.text = TexMath.to_unicode(sub)
             sub.tail = None  # tail is contained within the return value of to_unicode()
         text = etree.tostring(element, encoding="unicode", method="text")
-        text = remove_extra_whitespace(text)
-        return text
+        self._text = remove_extra_whitespace(text)
+        return self._text
 
     def as_html(self, allow_url: bool = True) -> str:
         """
@@ -112,6 +118,8 @@ class MarkupText:
         """
         if isinstance(self._content, str):
             return self._content
+        if self._html is not None:
+            return self._html
         element = deepcopy(self._content)
         for sub in element.iter():
             if sub.tag == "url":
@@ -128,18 +136,21 @@ class MarkupText:
                 parsed_elem = TexMath.to_html(sub)
                 parsed_elem.tail = sub.tail
                 sub.getparent().replace(sub, parsed_elem)  # type: ignore
-        html = remove_extra_whitespace(stringify_children(element))
-        return html
+        self._html = remove_extra_whitespace(stringify_children(element))
+        return self._html
 
     def as_latex(self) -> str:
         """
         Returns:
             Text with markup transformed into LaTeX commands."""
+        if self._latex is not None:
+            return self._latex
         if isinstance(self._content, str):
-            return latex_convert_quotes(latex_encode(self._content))
-        text = markup_to_latex(self._content)
-        text = remove_extra_whitespace(text)
-        return text
+            self._latex = latex_convert_quotes(latex_encode(self._content))
+        else:
+            latex = markup_to_latex(self._content)
+            self._latex = remove_extra_whitespace(latex)
+        return self._latex
 
     @classmethod
     def from_string(cls, text: str) -> MarkupText:

--- a/acl_anthology/utils/git.py
+++ b/acl_anthology/utils/git.py
@@ -56,8 +56,13 @@ def clone_or_pull_from_repo(
         )
         # ^-- It seems that Repo.clone_from() has an incorrect type signature
         # for its progress argument...
+    if progress is not None:
+        progress.progress.update(progress.task, completed=210.0)
+        progress.progress.stop()
 
 
+# This is a bit hacky, mainly to provide a "smoother" user experience, but
+# could probably be simplified.
 class RichRemoteProgress(RemoteProgress):
     def __init__(self) -> None:
         super().__init__()

--- a/acl_anthology/utils/ids.py
+++ b/acl_anthology/utils/ids.py
@@ -48,6 +48,11 @@ def build_id(
     Warning:
         Does not perform any kind of input validation.
     """
+    if not isinstance(collection_id, str):
+        msg = f"collection_id must be str; got {type(collection_id)}"
+        if isinstance(collection_id, (list, tuple)):
+            msg = f"{msg}; did you mean to use build_id_from_tuple?"
+        raise TypeError(msg)
     if volume_id is None:
         return collection_id
     elif collection_id[0].isdigit():

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,7 @@
 codecov:
   require_ci_to_pass: yes
   notify:
+    after_n_builds: 6
     wait_for_ci: yes
 
 coverage:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,8 @@
+codecov:
+  require_ci_to_pass: yes
+  notify:
+    wait_for_ci: yes
+
 coverage:
   range: 70..90
   status:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ ignore_missing_imports = true
 markers = [
     "integration: marks tests on the full acl-org/acl-anthology repo"
 ]
+testpaths = ["tests"]
 
 [tool.ruff]
 ignore = ['E501']  # "Line too long" is black's job

--- a/tests/anthology_integration_test.py
+++ b/tests/anthology_integration_test.py
@@ -23,7 +23,7 @@ DATADIR = Path(f"{SCRIPTDIR}/.official_anthology_git")
 
 @pytest.fixture
 def anthology_from_repo():
-    return Anthology.from_repo(path=DATADIR, verbose=True)
+    return Anthology.from_repo(path=DATADIR, verbose=False)
 
 
 @pytest.mark.integration

--- a/tests/anthology_test.py
+++ b/tests/anthology_test.py
@@ -97,6 +97,13 @@ def test_papers_by_volume_id(anthology):
     assert expected == found
 
 
+def test_get_person(anthology):
+    person = anthology.get_person("yang-liu-edinburgh")
+    assert person is not None
+    assert person.canonical_name == Name("Yang", "Liu")
+    assert person.comment == "Edinburgh"
+
+
 def test_find_people(anthology):
     people = anthology.find_people("Oliviero Stock")
     assert len(people) == 1

--- a/tests/anthology_test.py
+++ b/tests/anthology_test.py
@@ -97,6 +97,12 @@ def test_papers_by_volume_id(anthology):
     assert expected == found
 
 
+def test_find_people(anthology):
+    people = anthology.find_people("Oliviero Stock")
+    assert len(people) == 1
+    assert people[0].canonical_name == Name("Oliviero", "Stock")
+
+
 def test_resolve_single_author(anthology):
     name_spec = anthology.get_paper("J89-1001").authors[0]
     person = anthology.resolve(name_spec)

--- a/tests/collections/event_test.py
+++ b/tests/collections/event_test.py
@@ -141,6 +141,15 @@ def test_event_roundtrip_xml(xml):
     assert etree.tostring(out, encoding="unicode") == xml
 
 
+def test_event_volumes(anthology):
+    event = anthology.events.get("cl-1989")
+    assert str(event.title) == "Computational Linguistics (1989)"
+    assert len(event.colocated_ids) == 4
+    volumes = list(event.volumes())
+    assert len(volumes) == 4
+    assert {vol.full_id_tuple for vol in volumes} == set(event.colocated_ids)
+
+
 test_cases_talk_xml = (
     """<talk>
   <title>Keynote 1: Language in the human brain</title>

--- a/tests/collections/event_test.py
+++ b/tests/collections/event_test.py
@@ -148,6 +148,10 @@ def test_event_volumes(anthology):
     volumes = list(event.volumes())
     assert len(volumes) == 4
     assert {vol.full_id_tuple for vol in volumes} == set(event.colocated_ids)
+    with pytest.raises(ValueError):
+        # acl-2022 lists co-located volumes that we don't have in the toy
+        # dataset, so trying to access them should raise an error
+        list(anthology.events.get("acl-2022").volumes())
 
 
 test_cases_talk_xml = (

--- a/tests/collections/paper_test.py
+++ b/tests/collections/paper_test.py
@@ -46,6 +46,12 @@ def test_paper_minimum_attribs():
     assert paper.title == paper_title
 
 
+def test_paper_get_events(anthology):
+    paper = anthology.get_paper("2022.acl-demo.2")
+    assert paper is not None
+    assert paper.get_events() == [anthology.events["acl-2022"]]
+
+
 test_cases_xml = (
     """<frontmatter>
   <url hash="56ea4e43">2022.acl-long.0</url>

--- a/tests/collections/volume_test.py
+++ b/tests/collections/volume_test.py
@@ -202,6 +202,11 @@ def test_volume_with_nonexistent_venue(anthology):
         _ = volume.venues()
 
 
+def test_volume_get_events(anthology):
+    volume = anthology.get_volume("2022.acl-demo")
+    assert volume.get_events() == [anthology.events["acl-2022"]]
+
+
 @pytest.mark.parametrize("xml", test_cases_volume_xml)
 def test_volume_roundtrip_xml(xml):
     # Create and populate volume

--- a/tests/containers_test.py
+++ b/tests/containers_test.py
@@ -15,7 +15,7 @@
 import pytest
 
 from attrs import define, field
-from acl_anthology.containers import SlottedDict
+from acl_anthology.containers import dict_type, SlottedDict
 
 
 class BlankContainer(SlottedDict[str]):
@@ -163,3 +163,9 @@ def test_container_update(demo, other):
 def test_container_values(demo):
     values = {x for x in demo.values()}
     assert values == set((1, 2))
+
+
+def test_dict_type(demo):
+    assert dict_type(demo) == "int "
+    blank = BlankContainer()
+    assert dict_type(blank) == ""  # not determinable

--- a/tests/people/name_test.py
+++ b/tests/people/name_test.py
@@ -172,3 +172,13 @@ def test_name_from_string():
     n4 = Name.from_string("Mausam")
     assert n4.first is None
     assert n4.last == "Mausam"
+
+
+def test_name_from_any():
+    n1 = Name.from_("Jane Doe")
+    n2 = Name.from_({"first": "Jane", "last": "Doe"})
+    n3 = Name.from_(("Jane", "Doe"))
+    n4 = Name.from_(n1)
+    assert n1 == n2 == n3 == n4
+    with pytest.raises(TypeError):
+        Name.from_(["Jane", "Doe"])  # ... but could be allowed maybe?

--- a/tests/people/name_test.py
+++ b/tests/people/name_test.py
@@ -156,3 +156,19 @@ def test_name_scoring():
     assert n1.score() > n3.score()
     assert n1.score() > n4.score()
     assert n1.score() < n5.score()
+
+
+def test_name_from_string():
+    n1 = Name.from_string("André Rieu")
+    n2 = Name.from_string("Rieu, André")
+    assert n1.first == "André"
+    assert n1.last == "Rieu"
+    assert n1 == n2
+    n3 = Name.from_string("Chan, Tai Man")
+    assert n3.first == "Tai Man"
+    assert n3.last == "Chan"
+    with pytest.raises(ValueError):
+        Name.from_string("Tai Man Chan")
+    n4 = Name.from_string("Mausam")
+    assert n4.first is None
+    assert n4.last == "Mausam"

--- a/tests/people/person_test.py
+++ b/tests/people/person_test.py
@@ -48,3 +48,11 @@ def test_person_add_names(anthology_stub):
     person.add_name(n3)
     assert person.canonical_name == n2
     assert len(person.names) == 3
+
+
+def test_person_papers(anthology):
+    person = anthology.get_person("nicoletta-calzolari")
+    assert person.canonical_name == Name("Nicoletta", "Calzolari")
+    assert len(person.item_ids) == 3
+    assert len(list(person.papers())) == 2
+    assert len(list(person.volumes())) == 1

--- a/tests/people/person_test.py
+++ b/tests/people/person_test.py
@@ -15,31 +15,31 @@
 from acl_anthology.people import Name, Person
 
 
-def test_person_names():
+def test_person_names(anthology_stub):
     n1 = Name("Yang", "Liu")
     n2 = Name("Y.", "Liu")
     n3 = Name("Yang X.", "Liu")
-    person = Person("yang-liu", [n1, n2])
+    person = Person("yang-liu", anthology_stub, [n1, n2])
     assert len(person.names) == 2
     assert person.has_name(n1)
     assert person.has_name(n2)
     assert not person.has_name(n3)
 
 
-def test_person_canonical_names():
+def test_person_canonical_names(anthology_stub):
     n1 = Name("Yang", "Liu")
     n2 = Name("Y.", "Liu")
-    person = Person("yang-liu", [n1, n2])
+    person = Person("yang-liu", anthology_stub, [n1, n2])
     assert person.canonical_name == n1
     person.set_canonical_name(n2)
     assert person.canonical_name == n2
     assert len(person.names) == 2
 
 
-def test_person_add_names():
+def test_person_add_names(anthology_stub):
     n1 = Name("Yang", "Liu")
     n2 = Name("Y.", "Liu")
-    person = Person("yang-liu", [n1])
+    person = Person("yang-liu", anthology_stub, [n1])
     assert person.canonical_name == n1
     person.set_canonical_name(n2)
     assert person.canonical_name == n2

--- a/tests/people/personindex_test.py
+++ b/tests/people/personindex_test.py
@@ -55,7 +55,7 @@ def test_load_variant_list_correct_variants(index):
 
 
 def test_add_person(index):
-    p1 = Person("yang-liu", [Name("Yang", "Liu")])
+    p1 = Person("yang-liu", index.parent, [Name("Yang", "Liu")])
     index.add_person(p1)
     index.is_data_loaded = True  # to prevent it attempting to build itself
     assert "yang-liu" in index
@@ -65,7 +65,7 @@ def test_add_person(index):
     assert index.get_by_namespec(NameSpecification(Name("Yang", "Liu"))) is p1
     assert index.get("yang-liu") is p1
     with pytest.raises(KeyError):
-        index.add_person(Person("yang-liu"))
+        index.add_person(Person("yang-liu", index.parent))
 
 
 def test_get_or_create_person_with_id(index):

--- a/tests/utils/ids_test.py
+++ b/tests/utils/ids_test.py
@@ -51,6 +51,11 @@ def test_build_id_from_tuple(full_id, parsed):
     assert ids.build_id_from_tuple(parsed) == ids.build_id_from_tuple(full_id) == full_id
 
 
+def test_build_id_wrong_type():
+    with pytest.raises(TypeError):
+        ids.build_id(("P18", "1", "7"))
+
+
 test_cases_years = (
     ("P18-1007", "2018"),
     ("D19-1001", "2019"),


### PR DESCRIPTION
### Added

- Many new convenience functions, such as `Anthology.get_person()`, `Anthology.find_people()`, `Volume.get_events()`, `Person.papers()`, `Person.volumes()`.

### Changed

- Showing progress bars (i.e. `verbose=True`) is now the default.
- Shorter `repr()` output for many classes, sacrificing detail for better usability in interactive settings.
- `Person` objects now require a pointer to the Anthology instance.
